### PR TITLE
Handle ports without a service name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -196,9 +196,11 @@ export module nodenmap {
                                 tempHostList[hostLoopIter].openPorts[portLoopIter] = {};
                                 //Get the port number
                                 tempHostList[hostLoopIter].openPorts[portLoopIter].port = parseInt(xmlInput[hostLoopIter]["ports"][0]["port"][portLoopIter]['$']['portid']);
-                    
+
                                 //Get the port name
-                                tempHostList[hostLoopIter].openPorts[portLoopIter].service = xmlInput[hostLoopIter]["ports"][0]["port"][portLoopIter]['service'][0]['$']['name'];
+                                if (xmlInput[hostLoopIter]["ports"][0]["port"][portLoopIter]['service']) {
+                                    tempHostList[hostLoopIter].openPorts[portLoopIter].service = xmlInput[hostLoopIter]["ports"][0]["port"][portLoopIter]['service'][0]['$']['name'];
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
If you try to scan a port that nmap does not have a name for and that port is open, node-nmap prints an error that it is not able to find the service name. This patch fixes that by only adding the service property if it is available.