### PR TITLE
Fix scope issues with service related variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,22 +69,20 @@ function convertRawJsonToScanResults(xmlInput) {
 
       newHost.openPorts = openPorts.map((portItem) => {
         // console.log(JSON.stringify(portItem, null, 4))
+        let portObject = {}
 
         const port = parseInt(portItem.$.portid)
         const protocol = portItem.$.protocol
+
+        if(port) portObject.port = port
+        if(protocol) portObject.protocol = protocol
 
         if (portItem.service) {
           const service = portItem.service[0].$.name
           const tunnel = portItem.service[0].$.tunnel
           const method = portItem.service[0].$.method
           const product = portItem.service[0].$.tunnel
-        }
 
-        let portObject = {}
-        if(port) portObject.port = port
-        if(protocol) portObject.protocol = protocol
-
-        if (portItem.service) {
           if(service) portObject.service = service
           if(tunnel) portObject.tunnel = tunnel
           if(method) portObject.method = method


### PR DESCRIPTION
I had this error with the current master branch:

```
events.js:291
      throw er; // Unhandled 'error' event
      ^

ReferenceError: service is not defined
    at /opt/gestibox/node_modules/node-nmap/index.js:91:11
    at Array.map (<anonymous>)
    at /opt/gestibox/node_modules/node-nmap/index.js:70:37
    at Array.map (<anonymous>)
    at convertRawJsonToScanResults (/opt/gestibox/node_modules/node-nmap/index.js:34:27)
    at /opt/gestibox/node_modules/node-nmap/index.js:238:19
    at Parser.<anonymous> (/opt/gestibox/node_modules/xml2js/lib/parser.js:304:18)
    at Parser.emit (events.js:314:20)
    at SAXParser.onclosetag (/opt/gestibox/node_modules/xml2js/lib/parser.js:262:26)
    at emit (/opt/gestibox/node_modules/sax/lib/sax.js:624:35)
Emitted 'error' event on Parser instance at:
    at Parser.exports.Parser.Parser.parseString (/opt/gestibox/node_modules/xml2js/lib/parser.js:327:16)
    at Parser.parseString (/opt/gestibox/node_modules/xml2js/lib/parser.js:5:59)
    at Object.exports.parseString (/opt/gestibox/node_modules/xml2js/lib/parser.js:369:19)
    at NmapScan.rawDataHandler (/opt/gestibox/node_modules/node-nmap/index.js:232:12)
    at ChildProcess.<anonymous> (/opt/gestibox/node_modules/node-nmap/index.js:209:14)
    at ChildProcess.emit (events.js:314:20)
    at maybeClose (internal/child_process.js:1022:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
```